### PR TITLE
Fix hanging on low-entropy situations by backporting upstream fixes

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -15,6 +15,7 @@ import (
 	gocontext "golang.org/x/net/context"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/pkg/seed"
 	"github.com/containerd/containerd/server"
 	"github.com/containerd/containerd/sys"
 	"github.com/containerd/containerd/version"
@@ -40,6 +41,8 @@ func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version, version.Revision)
 	}
+
+	seed.WithTimeAndRand()
 }
 
 func Main() {

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -19,6 +19,7 @@ import (
 	versionCmd "github.com/containerd/containerd/cmd/ctr/commands/version"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/seed"
 	"github.com/containerd/containerd/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -34,6 +35,8 @@ func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version)
 	}
+
+	seed.WithTimeAndRand()
 }
 
 func Main() {

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -1,11 +1,11 @@
 package walking
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strings"
 	"time"

--- a/pkg/seed/seed.go
+++ b/pkg/seed/seed.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seed
+
+import (
+	"math/rand"
+	"time"
+)
+
+// WithTimeAndRand seeds the global math rand generator with nanoseconds
+// XOR'ed with a crypto component if available for uniqueness.
+func WithTimeAndRand() {
+	var (
+		b [4]byte
+		u int64
+	)
+
+	tryReadRandom(b[:])
+
+	// Set higher 32 bits, bottom 32 will be set with nanos
+	u |= (int64(b[0]) << 56) | (int64(b[1]) << 48) | (int64(b[2]) << 40) | (int64(b[3]) << 32)
+
+	rand.Seed(u ^ time.Now().UnixNano())
+}

--- a/pkg/seed/seed_linux.go
+++ b/pkg/seed/seed_linux.go
@@ -1,0 +1,24 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seed
+
+import "golang.org/x/sys/unix"
+
+func tryReadRandom(p []byte) {
+	// Ignore errors, just decreases uniqueness of seed
+	unix.Getrandom(p, unix.GRND_NONBLOCK)
+}

--- a/pkg/seed/seed_other.go
+++ b/pkg/seed/seed_other.go
@@ -1,0 +1,28 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seed
+
+import (
+	"crypto/rand"
+	"io"
+)
+
+func tryReadRandom(p []byte) {
+	io.ReadFull(rand.Reader, p)
+}

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -1,9 +1,9 @@
 package rootfs
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/containerd/containerd/diff"

--- a/services/leases/service.go
+++ b/services/leases/service.go
@@ -1,9 +1,9 @@
 package leases
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"google.golang.org/grpc"


### PR DESCRIPTION
Since updating our containerd fork would require more effort this just picks backports fixes from upstream.

Contains:
* https://github.com/containerd/containerd/commit/cce0a46c8ae04ead64084b9498b80125b1198221
* https://github.com/containerd/containerd/commit/9a97ab34cea0d54229de974853ed48bb23204ee1

Connects-to: https://github.com/balena-os/balena-engine/issues/105
Connects-to: https://github.com/containerd/containerd/issues/2451