### PR TITLE
Fix health command for balena-engine 17.x

### DIFF
--- a/cmd/ctr/commands/health/health.go
+++ b/cmd/ctr/commands/health/health.go
@@ -39,7 +39,7 @@ var Command = cli.Command{
 			return err
 		}
 
-		status := response.GetStatus()
+		status := response.Status
 		if status != health.HealthCheckResponse_SERVING {
 			return cli.NewExitError(status.String(), 1)
 		}


### PR DESCRIPTION
See https://travis-ci.org/balena-os/balena-engine/jobs/505192713

The GetStatus method was introduced in grpc-go 1.6.0, balena-engine
needs 1.3.0 (upgrading breaks other dependent packages).
This directly accesses the Status field instead.

Signed-off-by: Robert Günzler <robertg@balena.io>