### PR TITLE
cmd/containerd-shim: defer flag declaration until main

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -62,7 +62,7 @@ var (
 	containerdBinaryArgv0Flag string
 )
 
-func init() {
+func Main() {
 	flag.BoolVar(&debugFlag, "debug", false, "enable debug output in logs")
 	flag.StringVar(&namespaceFlag, "namespace", "", "namespace that owns the shim")
 	flag.StringVar(&socketFlag, "socket", "", "abstract socket path to serve")
@@ -75,9 +75,6 @@ func init() {
 	// The daemon invokes `containerd-shim -containerd-binary ...` with its own os.Executable() path.
 	flag.StringVar(&containerdBinaryFlag, "containerd-binary", "containerd", "path to containerd binary (used for `containerd publish`)")
 	flag.StringVar(&containerdBinaryArgv0Flag, "containerd-binary-argv0", "containerd", "argv0 to pass to containerd binary (used for `containerd publish`)")
-}
-
-func Main() {
 	flag.Parse()
 
 	debug.SetGCPercent(40)


### PR DESCRIPTION
Because of the binary consolidation this is necessary to avoid conflicts
when using the stdlib flag package (and the global flagset) somewhere else.

Signed-off-by: Robert Günzler <robertg@balena.io>

---

This is related to my work [here](https://github.com/balena-os/meta-balena/tree/rgz/a2o_migrate) and [here](https://github.com/balena-os/balena-engine/tree/a2o-migrate)
I get flag collisions with my overlay migration binary.